### PR TITLE
Image preview: Sort images based on timestamp and return the two newest.

### DIFF
--- a/src/routes/recordings.ts
+++ b/src/routes/recordings.ts
@@ -76,7 +76,7 @@ router.get('/pic/:name', (req: Request, res: Response) => {
 router.get('/last', async (req: Request, res: Response) => {
   try {
     exec(
-      `ls ${FRAMES_ROOT_FOLDER} | tail -2`,
+      `ls -t ${FRAMES_ROOT_FOLDER}/*.jpg | head -2`,
       {
         encoding: 'utf-8',
       },


### PR DESCRIPTION
Updating the preview logic to show the most recent two images. 

The HDC-S exposed an issue that the previous preview logic was relying on the fact that the files names where in order. With the HDC-S this was not true. Shift the logic to use the timestamp of the file. 