### PR TITLE
Add IMU calibration service.

### DIFF
--- a/src/config/hdc-s.ts
+++ b/src/config/hdc-s.ts
@@ -39,6 +39,7 @@ export const PRIVACY_ZONES_CONFIG = '/data/ppz.json';
 export const WEBSERVER_LOG_PATH = '/data/recording/odc-api.log';
 export const EVENTS_LOG_PATH = '/data/events.log';
 export const LED_CONFIG_PATH = __dirname + '/../../../tmp/led.json';
+export const IMU_CALIBRATOR_PATH = '/opt/dashcam/bin/imucalibrator';
 // File containing the camera configuration
 export const IMAGER_CONFIG_PATH =
   __dirname + '/../../../opt/camera-bridge/config.json';

--- a/src/config/hdc.ts
+++ b/src/config/hdc.ts
@@ -35,6 +35,7 @@ export const WEBSERVER_LOG_PATH =
   '/mnt/data/camera-node.log';
 export const EVENTS_LOG_PATH = '/mnt/data/events.log';
 export const LED_CONFIG_PATH = '/tmp/led.json';
+export const IMU_CALIBRATOR_PATH = '/opt/dashcam/bin/imucalibrator';
 export const CACHED_CAMERA_CONFIG = '/mnt/data/camera.conf';
 export const PRIVACY_ZONES_CONFIG = '/mnt/data/ppz.json';
 export const MOTION_MODEL_CURSOR = '/mnt/data/mm_cursor.log';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 export * from './hdc';
-export const API_VERSION = '3.5.5';
+export const API_VERSION = '3.6.5';
 
 export const isDev = () => {
   return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import busboy from 'connect-busboy';
 import { PUBLIC_FOLDER, PORT, TMP_PUBLIC_FOLDER } from './config';
 import { serviceRunner } from 'services';
 import { HeartBeatService } from 'services/heartBeat';
+import { InitIMUCalibrationService } from 'services/initIMUCalibration';
 import { InitCronService } from 'services/initCron';
 import { UpdateMotionModelConfigService } from 'services/updateMotionModelConfig';
 import { MotionModelService } from 'services/motionModel';
@@ -72,6 +73,7 @@ export async function initAppServer(): Promise<Application> {
     serviceRunner.add(HeartBeatService);
     serviceRunner.add(IntegrityCheckService);
     serviceRunner.add(DeviceInfoService);
+    serviceRunner.add(InitIMUCalibrationService);
     serviceRunner.add(InitCronService);
     serviceRunner.add(TrackDownloadDebt);
     serviceRunner.add(MotionModelService);

--- a/src/services/initIMUCalibration.ts
+++ b/src/services/initIMUCalibration.ts
@@ -1,0 +1,38 @@
+import { exec } from 'child_process';
+import { CAMERA_TYPE, IMU_CALIBRATOR_PATH } from 'config';
+import { promisify } from 'util';
+import { getConfig } from 'util/motionModel';
+import { CameraType, IService } from '../types';
+
+const calibrate = async (sensor: string) => {
+  const awaitableExec = promisify(exec);
+
+  console.log(`Calibrating ${sensor}.`);
+  await awaitableExec(`${IMU_CALIBRATOR_PATH} --sensor=${sensor} --clear-calibration`);
+  await awaitableExec(`${IMU_CALIBRATOR_PATH} --sensor=${sensor}`);
+
+  try {
+    await awaitableExec(`${IMU_CALIBRATOR_PATH} --sensor=${sensor} --verify-calibration`);
+  } catch (error) {
+    console.log(`${sensor} calibration failed, resetting to factory calibration`);
+    await awaitableExec(`${IMU_CALIBRATOR_PATH} --sensor=${sensor} --clear-calibration`);
+  }
+  console.log(`Completed ${sensor} calibration.`)
+}
+
+export const InitIMUCalibrationService: IService = {
+  execute: async () => {
+    if (CAMERA_TYPE === CameraType.Hdc) {
+      const config = getConfig();
+
+      if (config.isGyroCalibrationEnabled) {
+        await calibrate('gyro');
+      }
+
+      if (config.isAccelerometerCalibrationEnabled) {
+        await calibrate('accelerometer');
+      }
+    }
+  },
+  delay: 4000,
+};

--- a/src/types/motionModel.ts
+++ b/src/types/motionModel.ts
@@ -51,6 +51,8 @@ export type MotionModelConfig = {
   isCornerDetectionEnabled: boolean;
   isLightCheckDisabled: boolean;
   isDashcamMLEnabled: boolean;
+  isGyroCalibrationEnabled: boolean;
+  isAccelerometerCalibrationEnabled: boolean;
   rawLogsConfiguration: RawLogsConfiguration;
   privacyRadius?: number;
   modelHashes?: Record<string, string>;

--- a/src/util/motionModel.ts
+++ b/src/util/motionModel.ts
@@ -89,6 +89,8 @@ let config: MotionModelConfig = {
   isImuMovementDetectionEnabled: false,
   isLightCheckDisabled: false,
   isDashcamMLEnabled: false,
+  isGyroCalibrationEnabled: true,
+  isAccelerometerCalibrationEnabled: false,
   ImuFilter: defaultImu,
   rawLogsConfiguration: {
     isEnabled: false,


### PR DESCRIPTION
IMU calibration service will calibrate the device once on startup. If one of the calibrations fail, the calibration for that sensor will be cleared.

Gyro and accelerometer calibration are gated by flags `isGyroCalibrationEnabled` and `isAccelerometerCalibrationEnabled` and the accelerometer is disabled by default.

Ticket: [Method to call gyro & accelerometer calibration from odc-api#127](https://github.com/Hivemapper/odc-api/issues/127)

Depends on: [Add imucalibrator binary #199](https://github.com/Hivemapper/hdc_firmware/pull/199)
