### PR TITLE
Enable IMU calibration on HDC S.

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 export * from './hdc';
-export const API_VERSION = '3.6.5';
+export const API_VERSION = '3.7.0';
 
 export const isDev = () => {
   return false;

--- a/src/services/initIMUCalibration.ts
+++ b/src/services/initIMUCalibration.ts
@@ -1,8 +1,8 @@
 import { exec } from 'child_process';
-import { CAMERA_TYPE, IMU_CALIBRATOR_PATH } from 'config';
+import { IMU_CALIBRATOR_PATH } from 'config';
 import { promisify } from 'util';
 import { getConfig } from 'util/motionModel';
-import { CameraType, IService } from '../types';
+import { IService } from '../types';
 
 const calibrate = async (sensor: string) => {
   const awaitableExec = promisify(exec);
@@ -22,16 +22,14 @@ const calibrate = async (sensor: string) => {
 
 export const InitIMUCalibrationService: IService = {
   execute: async () => {
-    if (CAMERA_TYPE === CameraType.Hdc) {
-      const config = getConfig();
+    const config = getConfig();
 
-      if (config.isGyroCalibrationEnabled) {
-        await calibrate('gyro');
-      }
+    if (config.isGyroCalibrationEnabled) {
+      await calibrate('gyro');
+    }
 
-      if (config.isAccelerometerCalibrationEnabled) {
-        await calibrate('accelerometer');
-      }
+    if (config.isAccelerometerCalibrationEnabled) {
+      await calibrate('accelerometer');
     }
   },
   delay: 4000,


### PR DESCRIPTION
Enable IMU Calibration.  Requires hdcs_firmware image to be updated to include the imucalibrator binary.
