### PR TITLE
Workaround: remove max bound on lastTimestamp.

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 export * from './hdc';
-export const API_VERSION = '3.9.12';
+export const API_VERSION = '3.9.13';
 
 export const isDev = () => {
   return false;

--- a/src/sqlite/common.ts
+++ b/src/sqlite/common.ts
@@ -17,7 +17,7 @@ export const querySensorData = async (
   lastTimestamp: number, until?: number
 ): Promise<{ gnss: GnssRecord[]; imu: ImuRecord[]; images: IImage[] }> => {
   try {
-    const gnssSince = Math.max(lastTimestamp, Date.now() - 60 * 1000);
+    const gnssSince = lastTimestamp;
     console.log('Getting sensor data for: ', new Date(gnssSince));
     const start = Date.now();
     const gnssUntil = until ?? gnssSince + 120 * 1000; // restricting the GNSS query to 2 min max, to prevent accidental overloads

--- a/src/sqlite/common.ts
+++ b/src/sqlite/common.ts
@@ -14,17 +14,23 @@ let accumImuFreq = 0;
 let accumImageFreq = 0;
 
 export const querySensorData = async (
-  lastTimestamp: number, until?: number
+  since: number, until?: number
 ): Promise<{ gnss: GnssRecord[]; imu: ImuRecord[]; images: IImage[] }> => {
   try {
-    const gnssSince = lastTimestamp;
-    console.log('Getting sensor data for: ', new Date(gnssSince));
     const start = Date.now();
-    const gnssUntil = until ?? gnssSince + 120 * 1000; // restricting the GNSS query to 2 min max, to prevent accidental overloads
-    const gnss = (await fetchGnssLogsByTime(gnssSince, gnssUntil)).filter(g => g); // don't fetch more than a minute of data
+    console.log('Getting sensor data for: ', new Date(since));
+
+
+    // Restricting the GNSS query to 2 min max, to prevent accidental overloads.
+    // Note: if `until` argument is explicitly provided, we do not restrict it.
+    if (until === undefined) {
+      until = since + Math.min(start, 120 * 1000);
+    }
+
+    const gnss = (await fetchGnssLogsByTime(since, until)).filter(g => g);
     if (gnss.length) {
         const imuSince = gnss[0].system_time;
-        const imuUntil = Math.min(gnss[gnss.length - 1].system_time, until ?? imuSince + 120 * 1000); // restricting the IMU query to 2 min max, to prevent accidental overloads
+        const imuUntil = gnss[gnss.length - 1].system_time;
         const imu = await fetchImuLogsByTime(imuSince, imuUntil);
         const images = await getFramesFromFS(imuSince, imuUntil);
         const duration = (imuUntil - imuSince) / 1000;

--- a/src/sqlite/common.ts
+++ b/src/sqlite/common.ts
@@ -20,11 +20,10 @@ export const querySensorData = async (
     const start = Date.now();
     console.log('Getting sensor data for: ', new Date(since));
 
-
     // Restricting the GNSS query to 2 min max, to prevent accidental overloads.
     // Note: if `until` argument is explicitly provided, we do not restrict it.
     if (until === undefined) {
-      until = since + Math.min(start, 120 * 1000);
+      until = Math.min(start, since + 120 * 1000);
     }
 
     const gnss = (await fetchGnssLogsByTime(since, until)).filter(g => g);

--- a/src/util/motionModel/driveSession.ts
+++ b/src/util/motionModel/driveSession.ts
@@ -158,7 +158,8 @@ export class DriveSession {
     if (this.draftFrameKm && !this.draftFrameKm.isEmpty()) {
       return this.draftFrameKm.getLastTime();
     }
-    return (await getLastTimestamp()) ?? this.startedAt;
+    const date = (await getLastTimestamp()) ?? this.startedAt;
+    return Math.max(date, Date.now() - 60 * 1000);
   }
 
   async getNextFrameKMToProcess(): Promise<FrameKM | null> {


### PR DESCRIPTION
This was preventing making queries to times earlier than 1 minute ago, which broke sensor telemetry improvements.

Ticket: Hivemapper/mobile#1551

- [X] Add a link to the ticket in the PR title or add a description of work in the PR title
- [x] dashcam firmware was loaded on a device and successfully runs
- [x] semantic version was incremented inside `src/config/index.ts`
