### PR TITLE
Bugfix: use t instead of systemTime for querying GNSS Auth

### DIFF
--- a/src/util/motionModel/packaging.ts
+++ b/src/util/motionModel/packaging.ts
@@ -166,8 +166,8 @@ export const packMetadata = async (
     const deviceInfo = getDeviceInfo();
     const deviceId = await getAnonymousID();
 
-    const startTime = validatedFrames.at(0)?.systemTime ?? Date.now();
-    const endTime = validatedFrames.at(-1)?.systemTime ?? Date.now();
+    const startTime = validatedFrames.at(0)?.t || Date.now();
+    const endTime = validatedFrames.at(-1)?.t || Date.now();
     const gnssAuth = (await fetchGnssAuthLogsByTime(startTime, endTime, 1))[0];
     const metadataJSON = {
       bundle: {


### PR DESCRIPTION
Ticket: https://github.com/Hivemapper/docs/issues/366

- [x] Add a link to the ticket in the PR title or add a description of work in the PR title
- [x] dashcam firmware was loaded on a device and successfully runs
- [ ] semantic version was incremented inside `src/config/index.ts`
