### PR TITLE
Add deviceId to sensorquery.

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -279,13 +279,13 @@ router.get('/sensorquery', async (req: Request, res: Response) => {
   }
 
   const { gnss, imu } = await querySensorData(since, until);
-  const deviceId = await getAnonymousID();
+  const device_id = await getAnonymousID();
   const sensordata: SensorRecord[] = [];
   gnss.forEach(value => {
-    sensordata.push({ sensor: 'gnss', deviceId: deviceId, ...value });
+    sensordata.push({ sensor: 'gnss', device_id: device_id, ...value });
   });
   imu.forEach(value => {
-    sensordata.push({ sensor: 'imu', deviceId: deviceId, ...value });
+    sensordata.push({ sensor: 'imu', device_id: device_id, ...value });
   });
 
   res.json(sensordata);

--- a/src/types/sqlite.ts
+++ b/src/types/sqlite.ts
@@ -98,4 +98,4 @@ export type FrameKmRecord = {
 
   export type FrameKM = FrameKmRecord[];
   
-  export type SensorRecord = (GnssRecord | ImuRecord) & {sensor: string, deviceId: number};
+  export type SensorRecord = (GnssRecord | ImuRecord) & {sensor: string, device_id: number};

--- a/src/types/sqlite.ts
+++ b/src/types/sqlite.ts
@@ -98,4 +98,4 @@ export type FrameKmRecord = {
 
   export type FrameKM = FrameKmRecord[];
   
-  export type SensorRecord = (GnssRecord | ImuRecord) & {sensor: string, device_id: number};
+  export type SensorRecord = (GnssRecord | ImuRecord) & {sensor: string, device_id: string};

--- a/src/types/sqlite.ts
+++ b/src/types/sqlite.ts
@@ -98,4 +98,4 @@ export type FrameKmRecord = {
 
   export type FrameKM = FrameKmRecord[];
   
-  export type SensorRecord = (GnssRecord | ImuRecord) & {sensor: string};
+  export type SensorRecord = (GnssRecord | ImuRecord) & {sensor: string, deviceId: number};


### PR DESCRIPTION
Ticket: https://github.com/Hivemapper/hdcs_firmware/issues/66

Also removes /sensordata because that is no longer being used. This should cause no issues.  If there are older app versions out there that still use this, they will simply fail to retrieve sensor data

- [x] Add a link to the ticket in the PR title or add a description of work in the PR title
- [x] dashcam firmware was loaded on a device and successfully runs
- [ ] semantic version was incremented inside `src/config/index.ts`
