### PR TITLE
Change it so only 1% of FrameKMs contain GNSS Auth.

### DIFF
--- a/src/util/motionModel/packaging.ts
+++ b/src/util/motionModel/packaging.ts
@@ -24,7 +24,7 @@ import { getAnonymousID } from 'sqlite/deviceInfo';
 import { fetchGnssAuthLogsByTime } from 'sqlite/gnss_auth';
 import { getPublicKeyFromEeprom } from 'services/getPublicKeyFromEeprom';
 
-const CHANCE_OF_GNSS_AUTH_CHECK = 1.0;
+const CHANCE_OF_GNSS_AUTH_CHECK = 0.01;
 
 export const packFrameKm = async (frameKm: FrameKM) => {
   console.log('Ready to pack ' + frameKm.length + ' frames');


### PR DESCRIPTION
This will reduce demands on the server

Ticket: https://github.com/Hivemapper/network/issues/2083

- [X] Add a link to the ticket in the PR title or add a description of work in the PR title
- [x] dashcam firmware was loaded on a device and successfully runs
- [ ] semantic version was incremented inside `src/config/index.ts`
