### PR TITLE
Add deviceId to `/info` api.

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -80,6 +80,7 @@ router.get('/info', async (req: Request, res: Response) => {
     console.log('Build Info file is missing');
   }
   const deviceInfo = getDeviceInfo();
+  const deviceId = await getAnonymousID();
   res.json({
     ...versionInfo,
     ...deviceInfo,
@@ -89,6 +90,7 @@ router.get('/info', async (req: Request, res: Response) => {
       versionInfo && versionInfo.build_date
         ? new Date(versionInfo.build_date).toISOString()
         : undefined,
+    deviceId,
   });
 
   try {


### PR DESCRIPTION
Ticket: https://github.com/Hivemapper/mobile/issues/1732

This is needed to distinguish between data from different sessions.

- [X] Add a link to the ticket in the PR title or add a description of work in the PR title
- [X] dashcam firmware was loaded on a device and successfully runs
- [ ] semantic version was incremented inside `src/config/index.ts`
