### PR TITLE
Add APIs to retrieve magnetometer data

### DIFF
--- a/src/routes/db.ts
+++ b/src/routes/db.ts
@@ -5,6 +5,7 @@ import { fetchLastNErrorRecords } from 'sqlite/error';
 import { clearAll, getAllFrameKms, getFramesCount } from 'sqlite/framekm';
 import { fetchLastNGnssRecords } from 'sqlite/gnss';
 import { fetchLastNImuRecords } from 'sqlite/imu';
+import { fetchLastNMagnetometerRecords } from 'sqlite/magnetometer';
 
 const router = Router();
 
@@ -32,6 +33,16 @@ router.get('/imu/:n', async (req, res) => {
   const { n } = req.params;
   try {
     const rows = await fetchLastNImuRecords(Number(n));
+    res.send(rows);
+  } catch (error) {
+    res.status(500).send({ error });
+  }
+});
+
+router.get('/magnetometer/:n', async (req, res) => {
+  const { n } = req.params;
+  try {
+    const rows = await fetchLastNMagnetometerRecords(Number(n));
     res.send(rows);
   } catch (error) {
     res.status(500).send({ error });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -278,7 +278,7 @@ router.get('/sensorquery', async (req: Request, res: Response) => {
     return;
   }
 
-  const { gnss, imu } = await querySensorData(since, until);
+  const { gnss, imu, magnetometer } = await querySensorData(since, until);
   const device_id = await getAnonymousID();
   const sensordata: SensorRecord[] = [];
   gnss.forEach(value => {
@@ -286,6 +286,9 @@ router.get('/sensorquery', async (req: Request, res: Response) => {
   });
   imu.forEach(value => {
     sensordata.push({ sensor: 'imu', device_id: device_id, ...value });
+  });
+  magnetometer.forEach(value => {
+    sensordata.push({ sensor: 'magnetometer', device_id: device_id, ...value });
   });
 
   res.json(sensordata);

--- a/src/sqlite/magnetometer.ts
+++ b/src/sqlite/magnetometer.ts
@@ -1,0 +1,39 @@
+import { db } from './index';
+import { ImuRecord, MagnetometerRecord } from 'types/sqlite';
+import { convertTimestampToDbFormat } from 'util/index';
+
+export const fetchMagnetometerLogsByTime  = async (from: number, to?: number): Promise<MagnetometerRecord[]> => {
+    let query = `SELECT * FROM magnetometer WHERE system_time > ?`;
+    const args = [convertTimestampToDbFormat(from)];
+
+    if (to) {
+        query += ` AND system_time < ?`;
+        args.push(convertTimestampToDbFormat(to));
+    }
+    return new Promise((resolve) => {
+        db.all(query, args, (err: unknown, rows: MagnetometerRecord[]) => {
+            if (err) {
+                console.log(err);
+                resolve([]);
+            } else {
+                resolve(rows.filter(r => r).map(r => { 
+                    r.system_time = new Date(r.system_time + 'Z').getTime();
+                    return r;
+                }));
+            }
+        });
+    });
+}
+
+export const fetchLastNMagnetometerRecords = async (n: number): Promise<MagnetometerRecord[]> => {
+    const query = `SELECT * FROM magnetometer ORDER BY id DESC LIMIT ?`;
+    return new Promise((resolve, reject) => {
+        db.all(query, [n], (err: unknown, rows: MagnetometerRecord[]) => {
+            if (err) {
+              reject([]);
+            } else {
+              resolve(rows);
+            }
+          });
+    });
+}

--- a/src/types/sqlite.ts
+++ b/src/types/sqlite.ts
@@ -60,6 +60,13 @@ export interface GnssAuthRecord {
   system_time: number;
 }
 
+export interface MagnetometerRecord {
+  system_time: number;
+  mag_x: number;
+  mag_y: number;
+  mag_z: number;
+}
+
 export type FrameKmRecord = {
     fkm_id?: number;
     image_name: string;
@@ -98,4 +105,4 @@ export type FrameKmRecord = {
 
   export type FrameKM = FrameKmRecord[];
   
-  export type SensorRecord = (GnssRecord | ImuRecord) & {sensor: string, device_id: string};
+  export type SensorRecord = (GnssRecord | ImuRecord | MagnetometerRecord) & {sensor: string, device_id: string};


### PR DESCRIPTION
Added `/magnetometer/:n` endpoint and extended querySensorData to retrieve magnetometer data.
Added magnetometer data to the `/sensorquery` endpoint.

- [X] Add a link to the ticket in the PR title or add a description of work in the PR title
- [X] dashcam firmware was loaded on a device and successfully runs
- [ ] semantic version was incremented inside `src/config/index.ts`
