### PR TITLE
Pass odc version as an environment variable.

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 export * from './hdc';
-export const API_VERSION = '4.8.12';
+export const API_VERSION = process.env.ODC_VERSION || '1.0.0';
 
 export const isDev = () => {
   return false;


### PR DESCRIPTION
Ticket: https://github.com/Hivemapper/odc-api/issues/215

This allows us to specify the odc version via the service file.

- [x] Add a link to the ticket in the PR title or add a description of work in the PR title
- [x] dashcam firmware was loaded on a device and successfully runs
- [ ] semantic version was incremented inside `src/config/index.ts`
