### PR TITLE
Fix USB images not getting deleted in order.

### DIFF
--- a/src/util/lock.ts
+++ b/src/util/lock.ts
@@ -21,10 +21,8 @@ export const setGnssTime = (_gnssTime: number) => {
   // Workaround for usb circular write issue on HDC
   // See https://linear.app/hivemapper/issue/IMCO-166/investigate-hdc-recording-issue
   if (CAMERA_TYPE === CameraType.Hdc) {
-    console.log('Writing gnss time to /tmp/gnss_time.txt');
     fs.writeFile('/tmp/gnss_time.txt', gnssTime.toString(), () => {
       // Do nothing, best effort and we don't want to block.
-      console.log('gnss time written');
     });
   }
 }

--- a/src/util/lock.ts
+++ b/src/util/lock.ts
@@ -1,4 +1,7 @@
 import { exec, ExecException } from 'child_process';
+import fs from 'fs';
+import { CAMERA_TYPE } from 'config';
+import { CameraType } from 'types';
 
 export const DEFAULT_TIME = 1715027100000; // 2024-05-06, dashcam default time is less than this date. So once the date is bigger, we know that system time is set
 let lockTime = 0;
@@ -15,6 +18,15 @@ export const setTime = () => {
 let gnssTime = 0;
 export const setGnssTime = (_gnssTime: number) => {
   gnssTime = _gnssTime;
+  // Workaround for usb circular write issue on HDC
+  // See https://linear.app/hivemapper/issue/IMCO-166/investigate-hdc-recording-issue
+  if (CAMERA_TYPE === CameraType.Hdc) {
+    console.log('Writing gnss time to /tmp/gnss_time.txt');
+    fs.writeFile('/tmp/gnss_time.txt', gnssTime.toString(), () => {
+      // Do nothing, best effort and we don't want to block.
+      console.log('gnss time written');
+    });
+  }
 }
 
 export const getLatestGnssTime = () => {


### PR DESCRIPTION
Part of a workaround fix for USB circular writes.

Writes the GNSS timestamp to `/tmp/gnss_time.txt` periodically for `usb-write.py` to use.

Ticket: https://linear.app/hivemapper/issue/IMCO-166/investigate-hdc-recording-issue

- [X] Add a link to the ticket in the PR title or add a description of work in the PR title
- [X] dashcam firmware was loaded on a device and successfully runs
- [X] semantic version was incremented inside `src/config/index.ts`

Related to: https://github.com/Hivemapper/hdc_firmware/pull/258
