### PR TITLE
Write offset to gnss_time.txt instead of time

### DIFF
--- a/src/util/lock.ts
+++ b/src/util/lock.ts
@@ -23,8 +23,12 @@ export const setGnssTime = (_gnssTime: number) => {
   // See https://linear.app/hivemapper/issue/IMCO-166/investigate-hdc-recording-issue
   if (CAMERA_TYPE === CameraType.Hdc && !gnssOffsetWritten) {
     const gnssOffset = gnssTime - Date.now();
-    fs.writeFile('/tmp/gnss_time.txt', gnssOffset.toString(), () => {
-      gnssOffsetWritten = true;
+    fs.writeFile('/tmp/gnss_time.txt', gnssOffset.toString(), (err) => {
+      if (!err) {
+        gnssOffsetWritten = true;
+      } else {
+        console.log('Failed to write gnss offset', err);
+      }
     });
   }
 }

--- a/src/util/lock.ts
+++ b/src/util/lock.ts
@@ -21,7 +21,8 @@ export const setGnssTime = (_gnssTime: number) => {
   // Workaround for usb circular write issue on HDC
   // See https://linear.app/hivemapper/issue/IMCO-166/investigate-hdc-recording-issue
   if (CAMERA_TYPE === CameraType.Hdc) {
-    fs.writeFile('/tmp/gnss_time.txt', gnssTime.toString(), () => {
+    const gnssOffset = gnssTime - Date.now();
+    fs.writeFile('/tmp/gnss_time.txt', gnssOffset.toString(), () => {
       // Do nothing, best effort and we don't want to block.
     });
   }

--- a/src/util/lock.ts
+++ b/src/util/lock.ts
@@ -5,6 +5,7 @@ import { CameraType } from 'types';
 
 export const DEFAULT_TIME = 1715027100000; // 2024-05-06, dashcam default time is less than this date. So once the date is bigger, we know that system time is set
 let lockTime = 0;
+let gnssOffsetWritten = false;
 
 let timeSet = false;
 export const isTimeSet = () => {
@@ -20,10 +21,10 @@ export const setGnssTime = (_gnssTime: number) => {
   gnssTime = _gnssTime;
   // Workaround for usb circular write issue on HDC
   // See https://linear.app/hivemapper/issue/IMCO-166/investigate-hdc-recording-issue
-  if (CAMERA_TYPE === CameraType.Hdc) {
+  if (CAMERA_TYPE === CameraType.Hdc && !gnssOffsetWritten) {
     const gnssOffset = gnssTime - Date.now();
     fs.writeFile('/tmp/gnss_time.txt', gnssOffset.toString(), () => {
-      // Do nothing, best effort and we don't want to block.
+      gnssOffsetWritten = true;
     });
   }
 }


### PR DESCRIPTION
Ticket: https://linear.app/hivemapper/issue/IMCO-166/investigate-hdc-recording-issue

We now write the difference between gnss time and system time to the file.  Offset is relatively consistent, so there's no concern anymore that usb-write.py will read a stale gnss_offset.txt.

- [X] Add a link to the ticket in the PR title or add a description of work in the PR title
- [X] dashcam firmware was loaded on a device and successfully runs
- [ ] semantic version was incremented inside `src/config/index.ts`
